### PR TITLE
fix: add /provider directory for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,19 +1,32 @@
 version: 2
 updates:
   - package-ecosystem: "gomod"
-    directory: "/"
+    directory: "/provider"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+      time: "08:00"
+      day: "sunday"
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+  - package-ecosystem: "gomod"
+    directory: "/sdk"
+    schedule:
+      interval: "weekly"
+      day: "sunday"
       time: "08:00"
     labels:
       - "dependencies"
     commit-message:
-      prefix: "feat"
+      prefix: "chore"
       include: "scope"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+      day: "sunday"
       time: "08:00"
     labels:
       - "dependencies"


### PR DESCRIPTION
Hi,

This PR fixes the directory for the dependabot, when looking for go modules.