### PR TITLE
fix: add PUBLISH_NPM and PUBLISH_NUGET env variables

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,6 +18,8 @@ env:
   PYPI_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
   PYPI_USERNAME: "__token__"
   PUBLISH_PYPI: true
+  PUBLISH_NPM: true
+  PUBLISH_NUGET: true
 jobs:
   publish_binary:
     name: publish


### PR DESCRIPTION
Hi,

add missing env variables for PUBLISH_NPM and PUBLISH_NUGET

Should fix #23 